### PR TITLE
Adding more information in metadata and adding a let replacement

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,1 @@
+mvn deploy

--- a/deps.edn
+++ b/deps.edn
@@ -2,9 +2,9 @@
  {org.clojure/clojure {:mvn/version "1.10.1"}}
  :aliases
  {:dev
-  {:extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}
-                nubank/matcher-combinators {:mvn/version "1.2.4"}}}
+  {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.641"}
+                nubank/matcher-combinators {:mvn/version "3.1.1"}}}
 
   :test
-  {:extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}
-                nubank/matcher-combinators {:mvn/version "1.2.4"}}}}}
+  {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.641"}
+                nubank/matcher-combinators {:mvn/version "3.1.1"}}}}}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edenferreira</groupId>
   <artifactId>grasp</artifactId>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <name>grasp</name>
 
   <dependencies>

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -3,7 +3,14 @@
   (:require [clojure.pprint :as pprint])
   (:import [clojure.lang IObj]))
 
-(defn search-for-var [p]
+(defn search-for-var
+  "If the parameter is a value it looks for the var
+   that contains this value. For rich objects, like maps
+   vectors and the like it is precise, but for primitives
+   like numbers it will find the first var that contains that
+   number, but maybe will not find the one you were actually
+   looking for"
+  [p]
   (if (var? p)
     p
     (clojure.core/->> (all-ns)
@@ -34,7 +41,16 @@
   (reduce (fn [m sym] (assoc m `'~sym sym))
 	  {} (keys env)))
 
-(defmacro grab [exp]
+(defmacro grab
+  "It grabs the value of the expression parameter.
+   It also grabs local bindings, stacktrace and the original form
+   and adds to the metadata of the value if accepts metadata, so
+   primitives like numbers for example won't have this feature.
+
+   This can introduce a memory leak depending on the sink you are
+   using, for example if it is a atom, so keep this in mind and regularly
+   purge it if you have a long running repl and is grabbing a lot of value."
+  [exp]
   `(try
      (grab* ~exp
             '~&form

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -1,5 +1,5 @@
 (ns grasp
-  (:refer-clojure :exclude [-> ->>])
+  (:refer-clojure :exclude [-> ->> let])
   (:require [clojure.pprint :as pprint])
   (:import [clojure.lang IObj]))
 
@@ -50,12 +50,22 @@
 ;; Replacements
 
 (defmacro -> [& forms]
-  (let [forms' (interleave forms (repeat `grab))]
+  (clojure.core/let [forms' (interleave forms (repeat `grab))]
     `(clojure.core/-> ~@forms')))
 
 (defmacro ->> [& forms]
-  (let [forms' (interleave forms (repeat `grab))]
+  (clojure.core/let [forms' (interleave forms (repeat `grab))]
     `(clojure.core/->> ~@forms')))
+
+(defn emit-let-bindings [bindings]
+  (vec
+   (mapcat (fn [[b e]]
+             [b (list `grab e)])
+           (partition 2 bindings))))
+
+(defmacro let [bindings & body]
+  `(clojure.core/let ~(emit-let-bindings bindings)
+     ~@body))
 
 ;; Sinks
 

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -13,19 +13,20 @@
                       first
                       second)))
 
-(defn grab* [v]
+(defn grab* [v original-form]
   (tap> (if (instance? IObj v)
           (with-meta v
                      (merge (meta v)
-                            {::grasped? true}))
+                            {::grasped? true
+                             ::original-form original-form}))
           v))
   v)
 
 (defmacro grab [exp]
   `(try
-     (grab* ~exp)
+     (grab* ~exp '~&form)
      (catch Exception e#
-       (grab* e#)
+       (grab* e# '~&form)
        (throw e#))))
 
 (defn add-pretty-print-sink! []

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -47,6 +47,18 @@
               ~(local-bindings &env))
        (throw e#))))
 
+;; Replacements
+
+(defmacro -> [& forms]
+  (let [forms' (interleave forms (repeat `grab))]
+    `(clojure.core/-> ~@forms')))
+
+(defmacro ->> [& forms]
+  (let [forms' (interleave forms (repeat `grab))]
+    `(clojure.core/->> ~@forms')))
+
+;; Sinks
+
 (defn add-pretty-print-sink! []
   (add-tap pprint/pprint))
 
@@ -67,11 +79,3 @@
 
 (defn remove-rebl-sink! []
   (remove-tap rebl-sink))
-
-(defmacro -> [& forms]
-  (let [forms' (interleave forms (repeat `grab))]
-    `(clojure.core/-> ~@forms')))
-
-(defmacro ->> [& forms]
-  (let [forms' (interleave forms (repeat `grab))]
-    `(clojure.core/->> ~@forms')))

--- a/test/grasp_test.clj
+++ b/test/grasp_test.clj
@@ -1,7 +1,6 @@
 (ns grasp-test
   (:require [clojure.test :refer [deftest is testing]]
             [matcher-combinators.test :refer [match? thrown-match?]]
-            [clojure.pprint :as pprint]
             [grasp])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -17,11 +16,13 @@
            ~@forms)))))
 
 (deftest tap
-  (capturing-tap [tapped]
-    (is (= {:a 1} (grasp/grab {:a 1})))
-    (is (= [{:a 1}] @tapped))
-    (is (match? {:grasp/grasped? true}
-                (meta (last @tapped)))))
+  (let [a 1]
+    (capturing-tap [tapped]
+      (is (= {:a 1} (grasp/grab {:a a})))
+      (is (= [{:a 1}] @tapped))
+      (is (match? {:grasp/grasped? true
+                   :grasp/original-form '(grasp/grab {:a a})}
+                  (meta (last @tapped))))))
 
   (capturing-tap [tapped]
     (is (= 1 (grasp/grab 1)))
@@ -58,3 +59,6 @@
     (is (= 4 (grasp/->> 2 (- 3) (- 5))))
     (is (= [2 1 4]
            @tapped))))
+
+(comment
+  ((requiring-resolve `kaocha.repl/run) 'grasp-test))

--- a/test/grasp_test.clj
+++ b/test/grasp_test.clj
@@ -63,5 +63,14 @@
     (is (= [2 1 4]
            @tapped))))
 
+(deftest let-macro
+  (capturing-tap [tapped]
+    (is (= 5
+        (grasp/let [a 1
+                    b 3]
+          (+ 1 a b))))
+    (is (= [1 3]
+           @tapped))))
+
 (comment
   ((requiring-resolve `kaocha.repl/run) 'grasp-test))

--- a/test/grasp_test.clj
+++ b/test/grasp_test.clj
@@ -21,7 +21,8 @@
       (is (= {:a 1} (grasp/grab {:a a})))
       (is (= [{:a 1}] @tapped))
       (is (match? {:grasp/grasped? true
-                   :grasp/original-form '(grasp/grab {:a a})}
+                   :grasp/original-form '(grasp/grab {:a a})
+                   :grasp/locals {'a 1}}
                   (meta (last @tapped))))))
 
   (capturing-tap [tapped]

--- a/test/grasp_test.clj
+++ b/test/grasp_test.clj
@@ -1,6 +1,7 @@
 (ns grasp-test
   (:require [clojure.test :refer [deftest is testing]]
             [matcher-combinators.test :refer [match? thrown-match?]]
+            [matcher-combinators.matchers :as m]
             [grasp])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -22,7 +23,8 @@
       (is (= [{:a 1}] @tapped))
       (is (match? {:grasp/grasped? true
                    :grasp/original-form '(grasp/grab {:a a})
-                   :grasp/locals {'a 1}}
+                   :grasp/locals {'a 1}
+                   :grasp/stacktrace (m/pred (partial every? vector))}
                   (meta (last @tapped))))))
 
   (capturing-tap [tapped]


### PR DESCRIPTION
Metadata improvements: 
  We are adding the original form and local bindings in the metadata that is being grabbed, also adding the stacktrace in the point of grab as well to help with later debugging.
Let macro replacement:
  Added a let macro replacement that grabs every expression in with the same regular let macro syntax.

