### PR TITLE
Adding mapper to the grab

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edenferreira</groupId>
   <artifactId>grasp</artifactId>
-  <version>0.8.0</version>
+  <version>0.9.0</version>
   <name>grasp</name>
 
   <dependencies>


### PR DESCRIPTION
It is impossible to antecipate every debug style and requirement that
one prefers, and they can be different in different situations and
moments.
Here we added the mapper, a fn that will receive the meta and value and
return a new meta. We leave at the hand of the user to decide what they
want or not to see there.
We could have allowed to add multiple maps, but as of now this seem like
a unnecessary complexity, the use case that is thought of for this
library is one that you have control over the fn that you pass to the
mapper, so you can easily `comp` multiple if that's what you desire.