### PR TITLE
Implementing defn replacement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edenferreira</groupId>
   <artifactId>grasp</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0-SNAPSHOT</version>
   <name>grasp</name>
 
   <dependencies>

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -111,10 +111,14 @@
         forms-wo-meta (if (map? (first forms-wo-docstring))
                         (rest forms-wo-docstring)
                         forms-wo-docstring)
-        [parameters & body] forms-wo-meta]
-    `(clojure.core/defn ~name ~parameters
-       (grab ~parameters)
-       (grab (do  ~@body)))))
+        [parameters & body] forms-wo-meta
+        new-parameters (->> (range (count parameters))
+                            (mapv (comp gensym
+                                        (partial str "arg"))))]
+    `(clojure.core/defn ~name ~new-parameters
+       (grab ~new-parameters)
+       (clojure.core/let [~parameters ~new-parameters]
+         (grab (do ~@body))))))
 
 ;; Sinks
 

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -1,9 +1,9 @@
 (ns grasp
-  (:refer-clojure :exclude [-> ->> let])
+  (:refer-clojure :exclude [-> ->> let defn])
   (:require [clojure.pprint :as pprint])
   (:import [clojure.lang IObj]))
 
-(defn search-for-var
+(clojure.core/defn search-for-var
   "If the parameter is a value it looks for the var
    that contains this value. For rich objects, like maps
    vectors and the like it is precise, but for primitives
@@ -22,7 +22,7 @@
 
 (def ^:private mapper (atom (fn [m v] m)))
 
-(defn set-mapper!
+(clojure.core/defn set-mapper!
   "Receives a fn that will be passed the grab metadata and the value
    itself and should return a new metadata for the grab.
    The only meta that will be added by this lib regardless is the attribute
@@ -32,34 +32,34 @@
   (reset! mapper f)
   nil)
 
-(defn unset-mapper!
+(clojure.core/defn unset-mapper!
   "Remove any mapper added with `set-mapper!`"
   []
   (reset! mapper (fn [m v] m))
   nil)
 
-(defn grab* [v original-form exception locals]
+(clojure.core/defn grab* [v original-form exception locals]
   (tap> (if (instance? IObj v)
           (with-meta v
-                     (merge (meta v)
-                            (assoc
-                             (@mapper {::original-form original-form
-                                       ::locals locals
-                                       ::stacktrace (mapv StackTraceElement->vec
-                                                          (.getStackTrace exception))}
-                              v)
-                             ::grasped? true)))
+            (merge (meta v)
+                   (assoc
+                    (@mapper {::original-form original-form
+                              ::locals locals
+                              ::stacktrace (mapv StackTraceElement->vec
+                                                 (.getStackTrace exception))}
+                     v)
+                    ::grasped? true)))
           v))
   v)
 
 ;; shameslessly copied
 ;; https://github.com/stuartsierra/lazytest/blob/master/modules/lazytest/src/main/clojure/lazytest/expect.clj#L4-L8
 ;; what should I do EPL 1.0?
-(defn- local-bindings
+(clojure.core/defn- local-bindings
   "Returns a map of the names of local bindings to their values."
   [env]
   (reduce (fn [m sym] (assoc m `'~sym sym))
-	  {} (keys env)))
+          {} (keys env)))
 
 (defmacro grab
   "It grabs the value of the expression parameter.
@@ -93,7 +93,7 @@
   (clojure.core/let [forms' (interleave forms (repeat `grab))]
     `(clojure.core/->> ~@forms')))
 
-(defn emit-let-bindings [bindings]
+(clojure.core/defn emit-let-bindings [bindings]
   (vec
    (mapcat (fn [[b e]]
              [b (list `grab e)])
@@ -103,16 +103,29 @@
   `(clojure.core/let ~(emit-let-bindings bindings)
      ~@body))
 
+(defmacro defn [& forms]
+  (let [[name & forms] forms
+        forms-wo-docstring (if (string? (first forms))
+                             (rest forms)
+                             forms)
+        forms-wo-meta (if (map? (first forms-wo-docstring))
+                        (rest forms-wo-docstring)
+                        forms-wo-docstring)
+        [parameters & body] forms-wo-meta]
+    `(clojure.core/defn ~name ~parameters
+       (grab ~parameters)
+       (grab (do  ~@body)))))
+
 ;; Sinks
 
 (def pprint-sink! pprint/pprint)
 
-(defn form+value-sink [f v]
+(clojure.core/defn form+value-sink [f v]
   (if (::grasped? (meta v))
     (f (::original-form (meta v)) v)
     (f v v)))
 
-(defn rebl-sink! [v]
+(clojure.core/defn rebl-sink! [v]
   (form+value-sink
    (requiring-resolve `cognitect.rebl/submit)
    v))

--- a/test/grasp_test.clj
+++ b/test/grasp_test.clj
@@ -103,7 +103,7 @@
 (grasp/defn triple "triple" [c]
   (* c 3))
 
-(grasp/defn concatenate {:unnecessary :complicated} [a b c]
+(grasp/defn concatenate-from-map {:unnecessary :complicated} [{:keys [a b c]}]
   (println a b c)
   (concat a b c))
 
@@ -117,8 +117,16 @@
     (is (= [[7] 21] @tapped)))
 
   (capturing-tap [tapped]
-    (is (= [1 5 8] (concatenate [1] [5] [8])))
-    (is (= [[[1] [5] [8]] [1 5 8]] @tapped))))
+    (let [a 1
+          b 5
+          c 8]
+      (is (= [1 5 8] (concatenate-from-map {:a [a]
+                                            :b [b]
+                                            :c [c]})))
+      (is (= [[{:a [1]
+                :b [5]
+                :c [8]}]
+              [1 5 8]] @tapped)))))
 
 ;; Sinks
 

--- a/test/grasp_test.clj
+++ b/test/grasp_test.clj
@@ -97,6 +97,29 @@
     (is (= [1 3]
            @tapped))))
 
+(grasp/defn add [a b]
+  (+ a b))
+
+(grasp/defn triple "triple" [c]
+  (* c 3))
+
+(grasp/defn concatenate {:unnecessary :complicated} [a b c]
+  (println a b c)
+  (concat a b c))
+
+(deftest defn-macro
+  (capturing-tap [tapped]
+    (is (= 42 (add 19 23)))
+    (is (= [[19 23] 42] @tapped)))
+
+  (capturing-tap [tapped]
+    (is (= 21 (triple 7)))
+    (is (= [[7] 21] @tapped)))
+
+  (capturing-tap [tapped]
+    (is (= [1 5 8] (concatenate [1] [5] [8])))
+    (is (= [[[1] [5] [8]] [1 5 8]] @tapped))))
+
 ;; Sinks
 
 (deftest form+value-sink


### PR DESCRIPTION
This replacement will grab the parameters and the return.
It takes care of some of the different ways you can define a function,
but not all of them, just the ones that I use the most, but if we need
for some that is not covered it can be improved later.

Still TODO:
- [ ] Improve form that is grabbed from the parameters