### PR TITLE
Adding persistent sink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>edenferreira</groupId>
   <artifactId>grasp</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <name>grasp</name>
 
   <dependencies>

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -117,7 +117,6 @@
    (requiring-resolve `cognitect.rebl/submit)
    v))
 
-(def log-initial-value [])
-(def log (atom log-initial-value))
+(def log (atom []))
 (defn persistent-sink! [v]
   (swap! log conj v))

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -118,5 +118,10 @@
    v))
 
 (def log (atom []))
-(defn persistent-sink! [v]
+(defn persistent-sink!
+  "It appends the value to the grasp/log atom.
+   It is a sequence, so to get the last value you can just
+  (last @grasp/log) and to reset the value you can
+  (swap! grasp/log empty)."
+  [v]
   (swap! log conj v))

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -116,3 +116,8 @@
   (form+value-sink
    (requiring-resolve `cognitect.rebl/submit)
    v))
+
+(def log (atom []))
+
+(defn persistent-sink! [v]
+  (swap! log conj v))

--- a/src/grasp.clj
+++ b/src/grasp.clj
@@ -117,7 +117,7 @@
    (requiring-resolve `cognitect.rebl/submit)
    v))
 
-(def log (atom []))
-
+(def log-initial-value [])
+(def log (atom log-initial-value))
 (defn persistent-sink! [v]
   (swap! log conj v))

--- a/test/grasp_test.clj
+++ b/test/grasp_test.clj
@@ -117,9 +117,18 @@
              @result)))))
 
 (deftest persistent-sink!
-  (grasp/persistent-sink! ::some-value)
-  (is (= [::some-value]
-         @grasp/log)))
+  (testing "we persist a simple value in the log"
+    (reset! grasp/log [])
+    (grasp/persistent-sink! ::some-value)
+    (is (= [::some-value]
+           @grasp/log)))
+
+  (testing "the metadata is also persisted"
+    (reset! grasp/log [])
+    (grasp/persistent-sink! (with-meta {::some ::value}
+                              {::my ::meta}))
+    (is (= [{::my ::meta}]
+           (map meta @grasp/log)))))
 
 (comment
   ((requiring-resolve `kaocha.repl/run) *ns*))

--- a/test/grasp_test.clj
+++ b/test/grasp_test.clj
@@ -116,5 +116,10 @@
       (is (= [[value value]]
              @result)))))
 
+(deftest persistent-sink!
+  (grasp/persistent-sink! ::some-value)
+  (is (= [::some-value]
+         @grasp/log)))
+
 (comment
   ((requiring-resolve `kaocha.repl/run) *ns*))


### PR DESCRIPTION
This sink conj the grabbed value to a atom.
The atom itself is public, the user can reset at any point to avoid blowing up the memory if required.